### PR TITLE
improved quiz creation page performance

### DIFF
--- a/resources/js/quiz.js
+++ b/resources/js/quiz.js
@@ -910,7 +910,7 @@ const MCQ = (props) => {
                 questionIndex={props.questionIndex}
                 optionIndex={index}
                 sectionIndex={props.sectionIndex}
-                key={index}
+                key={option.id}
                 type={props.type}
               />
             ))}
@@ -1158,7 +1158,7 @@ const Section = (props) => {
         sectionNumber={props.sectionNumber}
         sectionIndex={props.sectionNumber - 1}
         totalSections={props.totalSections}
-        key={props.sectionNumber + "a"}
+        key={state.mcqs[props.sectionNumber - 1].id + "a"}
         autoPoolCount={autoPoolCount}
         setAutoPoolCount={setAutoPoolCount}
       />
@@ -1169,7 +1169,7 @@ const Section = (props) => {
               sectionIndex={props.sectionIndex}
               questionIndex={index}
               type={question.type}
-              key={index}
+              key={question.id}
             ></MCQ>
           ) : (
             <div>
@@ -1182,7 +1182,7 @@ const Section = (props) => {
                 sectionIndex={props.sectionIndex}
                 questionIndex={index}
                 type={question.type}
-                key={index}
+                key={question.id}
               ></MCQ>
             </div>
           );
@@ -1193,7 +1193,7 @@ const Section = (props) => {
         sectionNumber={props.sectionNumber}
         sectionIndex={props.sectionNumber - 1}
         totalSections={props.totalSections}
-        key={props.sectionNumber + "b"}
+        key={state.mcqs[props.sectionNumber - 1].id + "b"}
         autoPoolCount={autoPoolCount}
         setAutoPoolCount={setAutoPoolCount}
       />

--- a/resources/precompiled-js/quiz.js
+++ b/resources/precompiled-js/quiz.js
@@ -729,7 +729,7 @@ var MCQ = function MCQ(props) {
       questionIndex: props.questionIndex,
       optionIndex: index,
       sectionIndex: props.sectionIndex,
-      key: index,
+      key: option.id,
       type: props.type
     });
   })), /*#__PURE__*/React.createElement("hr", {
@@ -926,7 +926,7 @@ var Section = function Section(props) {
     sectionNumber: props.sectionNumber,
     sectionIndex: props.sectionNumber - 1,
     totalSections: props.totalSections,
-    key: props.sectionNumber + "a",
+    key: state.mcqs[props.sectionNumber - 1].id + "a",
     autoPoolCount: autoPoolCount,
     setAutoPoolCount: setAutoPoolCount
   }), /*#__PURE__*/React.createElement("div", null, state.mcqs[props.sectionIndex].questions.map(function (question, index) {
@@ -934,7 +934,7 @@ var Section = function Section(props) {
       sectionIndex: props.sectionIndex,
       questionIndex: index,
       type: question.type,
-      key: index
+      key: question.id
     }) : /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement(Passage, {
       passageIndex: question.passage,
       sectionIndex: props.sectionIndex,
@@ -943,14 +943,14 @@ var Section = function Section(props) {
       sectionIndex: props.sectionIndex,
       questionIndex: index,
       type: question.type,
-      key: index
+      key: question.id
     }));
   })), /*#__PURE__*/React.createElement(SectionHeader, {
     sectionTitle: props.sectionTitle,
     sectionNumber: props.sectionNumber,
     sectionIndex: props.sectionNumber - 1,
     totalSections: props.totalSections,
-    key: props.sectionNumber + "b",
+    key: state.mcqs[props.sectionNumber - 1].id + "b",
     autoPoolCount: autoPoolCount,
     setAutoPoolCount: setAutoPoolCount
   }));

--- a/routes/quiz.js
+++ b/routes/quiz.js
@@ -198,6 +198,7 @@ router.get("/state/:quizId", checkAdminAuthenticated, async (req, res) => {
     });
     for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
       stateObject.push({
+        id: sections[sectionIndex].id,
         sectionTitle: sections[sectionIndex].title,
         sectionOrder: sections[sectionIndex].sectionOrder,
         poolCount: sections[sectionIndex].poolCount,
@@ -214,6 +215,7 @@ router.get("/state/:quizId", checkAdminAuthenticated, async (req, res) => {
         questionIndex++
       ) {
         stateObject[sectionIndex].questions.push({
+          id: questions[questionIndex].id,
           passage:
             questions[questionIndex].PassageId != null
               ? findAndReturnPassageIndexFromPassagesArrayUsingPassageId(
@@ -238,6 +240,7 @@ router.get("/state/:quizId", checkAdminAuthenticated, async (req, res) => {
         });
         for (let optionIndex = 0; optionIndex < options.length; optionIndex++) {
           stateObject[sectionIndex].questions[questionIndex].options.push({
+            id: options[optionIndex].id,
             optionStatement: options[optionIndex].statement,
             optionOrder: options[optionIndex].optionOrder,
             correct: options[optionIndex].correct,


### PR DESCRIPTION
Previously, we were using array indices as React `key` attributes.
That reduces performance when the list grows large and causes unnecessary renders. Changing key attribute to use Database IDs instead which are more reliable.

From ReactJS docs:
<img width="763" alt="image" src="https://user-images.githubusercontent.com/34311857/197387315-ab59fc7f-5aa2-482a-ab41-597407106742.png">
